### PR TITLE
Compatibility with SummarizedExperiment >= 1.23.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: SplicingFactory
 Type: Package
 Title: Splicing Diversity Analysis for Transcriptome Data
 biocViews: Transcriptomics, RNASeq, DifferentialSplicing, AlternativeSplicing, TranscriptomeVariant
-Version: 1.1.4
+Version: 1.1.5
 Authors@R: c(
     person("Peter A.", "Szikora", role = c("aut"), email = "peter.andras.szikora@gmail.com"),
     person("Tamas", "Por", role = c("aut"), email = "tomasz.por@gmail.com"),

--- a/R/calculate_diversity.R
+++ b/R/calculate_diversity.R
@@ -171,6 +171,7 @@ calculate_diversity <- function(x, genes = NULL, method = "laplace", norm = TRUE
   result <- calculate_method(x, genes, method, norm, verbose = verbose)
 
   result_assay <- result[, -1, drop = FALSE]
+  rownames(result_assay) <- result[, 1]
   result_rowData <- data.frame(genes = result[, 1], row.names = result[, 1])
   result_colData <- data.frame(samples = colnames(x), row.names = colnames(x))
   result_metadata <- list(method = method, norm = norm)


### PR DESCRIPTION
Make sure that the rownames on the supplied assay and rowData are the same when calling the `SummarizedExperiment()` constructor. This is a new requirement in **SummarizedExperiment** >= 1.23.2.

This fixes https://bioconductor.org/checkResults/3.14/bioc-LATEST/SplicingFactory/nebbiolo2-buildsrc.html